### PR TITLE
Add light theme, add highlighting, add passing latitude and longitudevia the url

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ night. The hour hand is the sun traveling across the sky.
 
 You can highlight certain hours by adding search parameters of the form `hl=<integer>` or `hl=<hour name>` to the url, for example [`https://seasonalclock.org/?hl=6&h=rainbow`](https://seasonalclock.org/?hl=6&h=rainbow) to highlight sprout hour (UTC+6) and rainbow hour.
 
-You can specify a latitude and longitude in the url that is used for displaying sun hours, by adding search parameters of the form `lat=<float>` and `lon=<float>` to the url (both have to be present), for example [`https://seasonalclock.org/?lat=52.31&lon=13.24`](https://seasonalclock.org/?hl=6&h=rainbow). You can combine this with highlighting: [`https://seasonalclock.org/?lat=52.31&lon=13.24&hl=6&h=rainbow`](https://seasonalclock.org/?hl=6&h=rainbow&hl=6&h=rainbow)
+You can specify a latitude and longitude in the url that is used for displaying sun hours, by adding search parameters of the form `lat=<float>` and `lon=<float>` to the url (both have to be present), for example [`https://seasonalclock.org/?lat=52.31&lon=13.24`](https://seasonalclock.org/?lat=52.31&lon=13.24).
+
+You can specify an offset from utc in the url to override the time displayed in the outer circle, by adding a parameter `offset=<float>` to the url, for example [`https://seasonalclock.org/?offset=5`](https://seasonalclock.org/?offset=5). Combine this with setting latitude and longitude to create links that show local time and sun hours for arbitrary locations:
+
+- Berlin in summer (latitude 52.31 degrees, longitude 13.24 degrees, UTC+2): [`https://seasonalclock.org/?lat=52.31&lon=13.24&offset=2`](https://seasonalclock.org/?lat=52.31&lon=13.24&offset=2)
+- Wellington (latitude 41.17 degrees, longitude 174.46 degrees, UTC+12): [`https://seasonalclock.org/?lat=41.17&lon=174.46&offset=12`](https://seasonalclock.org/?lat=41.17&lon=174.46&offset=12)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can specify a latitude and longitude in the url that is used for displaying 
 You can specify an offset from utc in the url to override the time displayed in the outer circle, by adding a parameter `offset=<float>` to the url, for example [`https://seasonalclock.org/?offset=5`](https://seasonalclock.org/?offset=5). Combine this with setting latitude and longitude to create links that show local time and sun hours for arbitrary locations:
 
 - Berlin in summer (latitude 52.31 degrees, longitude 13.24 degrees, UTC+2): [`https://seasonalclock.org/?lat=52.31&lon=13.24&offset=2`](https://seasonalclock.org/?lat=52.31&lon=13.24&offset=2)
-- Wellington (latitude 41.17 degrees, longitude 174.46 degrees, UTC+12): [`https://seasonalclock.org/?lat=41.17&lon=174.46&offset=12`](https://seasonalclock.org/?lat=41.17&lon=174.46&offset=12)
+- Wellington (latitude -41.17 degrees, longitude 174.46 degrees, UTC+12): [`https://seasonalclock.org/?lat=-41.17&lon=174.46&offset=12`](https://seasonalclock.org/?lat=-41.17&lon=174.46&offset=12)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ summer is yellow, autumn is orange.
 The colored pie chart in the middle shows sunset times: daylight, dusk, and
 night. The hour hand is the sun traveling across the sky.
 
+You can highlight certain hours by adding search parameters of the form `hl=<integer>` or `hl=<hour name>` to the url, for example [`https://seasonalclock.org/?hl=6&h=rainbow`](https://seasonalclock.org/?hl=6&h=rainbow) to highlight sprout hour (UTC+6) and rainbow hour.
+
+You can specify a latitude and longitude in the url that is used for displaying sun hours, by adding search parameters of the form `lat=<float>` and `lon=<float>` to the url (both have to be present), for example [`https://seasonalclock.org/?lat=52.31&lon=13.24`](https://seasonalclock.org/?hl=6&h=rainbow). You can combine this with highlighting: [`https://seasonalclock.org/?lat=52.31&lon=13.24&hl=6&h=rainbow`](https://seasonalclock.org/?hl=6&h=rainbow&hl=6&h=rainbow)
+
 ---
 
 [seasonal-hours.ts](https://github.com/sgwilym/seasonal-hours-clock/blob/main/src/seasonal-hours.ts)

--- a/public/index.html
+++ b/public/index.html
@@ -1,17 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-	<meta name="theme-color" content="#000000">
-	<!--
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <meta name="theme-color" content="#000000" />
+    <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
     -->
-	<link rel="manifest" href="%PUBLIC_URL%/manifest.json">
-	<link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
-	<!--
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+    <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -21,39 +23,35 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Seasonal Hours Clock</title>
-	<link rel="stylesheet" href="%PUBLIC_URL%/font.css">
+    <link rel="stylesheet" href="%PUBLIC_URL%/font.css" />
     <style>
-        * {
-            font-family: 'Vollkorn', monospace, sans-serif;
-            /*
+      * {
+        font-family: "Vollkorn", monospace, sans-serif;
+        /*
             font-family: 'Vollkorn SC', 'Vollkorn', sans-serif;
             font-variant: 'small-caps';
             font-weight: 600;
             */
-        }
-    </style>
-</head>
+      }
 
-<body>
-	<noscript>
-		You need to enable JavaScript to run this app.
+      body {
+        display: grid;
+        place-content: center;
+        height: 100vh;
+        margin: 0;
+      }
+    </style>
+  </head>
+
+  <body>
+    <noscript>
+      You need to enable JavaScript to run this app.
     </noscript>
-    <div class='github-link'>
-        <a href="https://github.com/cinnamon-bun/seasonal-hours-clock/tree/main/">
-            source code
-        </a>
+    <div class="github-link">
+      <a href="https://github.com/sgwilym/seasonal-hours-clock">
+        source code
+      </a>
     </div>
     <div id="root"></div>
-	<!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
-</body>
-
+  </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -23,10 +23,6 @@
     <title>Seasonal Hours Clock</title>
 	<link rel="stylesheet" href="%PUBLIC_URL%/font.css">
     <style>
-        body {
-            background-color: black;
-            color: white;
-        }
         * {
             font-family: 'Vollkorn', monospace, sans-serif;
             /*
@@ -34,15 +30,6 @@
             font-variant: 'small-caps';
             font-weight: 600;
             */
-        }
-        a {
-            color: #333;
-            text-decoration: none;
-        }
-        .github-link {
-            position: fixed;
-            top: 10px;
-            left: 10px;
         }
     </style>
 </head>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,23 +81,13 @@ let computeSunTimes = (loc: Location | null) => {
 // MAIN
 
 let hourToString = (n: number): string => {
-  if (n === 12) {
-    return "Noon";
+  const nToUse = (n + 12) % 24;
+
+  if (nToUse < 10) {
+    return `0${nToUse}`;
   }
-  if (n === 0) {
-    return "Midnight";
-  }
-  if (config.useAmPm) {
-    let isAm = n <= 11;
-    let ampm = isAm ? "a" : "p";
-    let n2 = n % 12;
-    if (n2 === 0) {
-      n2 = 12;
-    }
-    return `${n2}${ampm}`;
-  } else {
-    return ("" + n).padStart(2, "0");
-  }
+
+  return `${nToUse}`;
 };
 
 export default function App() {
@@ -237,6 +227,23 @@ export default function App() {
               classNameText: "sFillInkFaint"
             }))}
           />
+          <Dial
+            cx={cx}
+            cy={cy}
+            radMax={radMax * 1.01}
+            radMin={radMax * 0.9}
+            textAlign="center-range"
+            ticks={range(24).map((n) => {
+              let moji = hourTable[n].emoji;
+
+              return {
+                angle: (360 * n) / 24,
+                text: moji,
+                className: "sNone",
+                classNameText: "sFillInkFaint"
+              };
+            })}
+          />
         </Rotate>
 
         {/* outer ring: local time */}
@@ -249,7 +256,7 @@ export default function App() {
           textScale={0.62}
           ticks={range(24).map((n) => ({
             angle: (360 * n) / 24,
-            text: hourToString((n + 12) % 24),
+            text: hourToString(n),
             className: "sNone",
             classNameText: "sFillInk"
           }))}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,20 +7,7 @@ import { config } from "./config";
 import { dayPct, nop, range } from "./util";
 import { Pie, Rec, Rotate } from "./svg-utils";
 import { Dial } from "./dial";
-import {
-  cInk,
-  cInkFaint,
-  sCivilDusk,
-  sDay,
-  sFillDebug,
-  sFillInk,
-  sFillSeasonLookup,
-  sLineDebug,
-  sLineInk,
-  sNauticalDusk,
-  sNight,
-  sNone,
-} from "./styles";
+import { sFillDebug, sFillSeasonLookup, sLineDebug } from "./styles";
 import { useTimer } from "./hooks";
 import { hourTable } from "./seasonal-hours";
 
@@ -49,14 +36,14 @@ let requestLocFromBrowser = async (): Promise<Location | null> => {
       (result) => {
         let loc: Location = {
           lat: result.coords.latitude,
-          lon: result.coords.longitude,
+          lon: result.coords.longitude
         };
         res(loc);
       },
       (err) => {
         console.warn(err);
         res(null);
-      },
+      }
     );
   });
   return prom;
@@ -94,13 +81,23 @@ let computeSunTimes = (loc: Location | null) => {
 // MAIN
 
 let hourToString = (n: number): string => {
-  const nToUse = (n + 12) % 24;
-
-  if (nToUse < 10) {
-    return `0${nToUse}`;
+  if (n === 12) {
+    return "Noon";
   }
-
-  return `${nToUse}`;
+  if (n === 0) {
+    return "Midnight";
+  }
+  if (config.useAmPm) {
+    let isAm = n <= 11;
+    let ampm = isAm ? "a" : "p";
+    let n2 = n % 12;
+    if (n2 === 0) {
+      n2 = 12;
+    }
+    return `${n2}${ampm}`;
+  } else {
+    return ("" + n).padStart(2, "0");
+  }
 };
 
 export default function App() {
@@ -142,19 +139,17 @@ export default function App() {
         <circle cx={cx} cy={cy} r={res / 2} style={sLineDebug} />
 
         {/* daylight */}
-        {sunTimes !== null && config.showSunTimes
-          ? (
-            <Pie
-              cx={cx}
-              cy={cy}
-              angle1={dayPct(sunTimes.sunrise) * 360 + 180}
-              angle2={dayPct(sunTimes.sunset) * 360 + 180}
-              rMin={radMax * 0}
-              rMax={radMax * 0.7}
-              style={sDay}
-            />
-          )
-          : undefined}
+        {sunTimes !== null && config.showSunTimes ? (
+          <Pie
+            cx={cx}
+            cy={cy}
+            angle1={dayPct(sunTimes.sunrise) * 360 + 180}
+            angle2={dayPct(sunTimes.sunset) * 360 + 180}
+            rMin={radMax * 0}
+            rMax={radMax * 0.7}
+            className={"sDay"}
+          />
+        ) : undefined}
 
         {/* sun */}
         <Rotate cx={cx} cy={cy} angle={nowDayPct * 360}>
@@ -162,54 +157,48 @@ export default function App() {
             cx={cx}
             cy={cy + radMax * 0.5}
             r={radMax * 0.035}
-            style={sFillInk}
+            className={"sFillInk"}
           />
         </Rotate>
 
         {/* sunset to civil dusk */}
-        {sunTimes !== null && config.showSunTimes
-          ? (
-            <Pie
-              cx={cx}
-              cy={cy}
-              angle1={dayPct(sunTimes.sunset) * 360 - 180}
-              angle2={dayPct(sunTimes.sunrise) * 360 + 180}
-              rMin={radMax * 0}
-              rMax={radMax * 0.7}
-              style={sCivilDusk}
-            />
-          )
-          : undefined}
+        {sunTimes !== null && config.showSunTimes ? (
+          <Pie
+            cx={cx}
+            cy={cy}
+            angle1={dayPct(sunTimes.sunset) * 360 - 180}
+            angle2={dayPct(sunTimes.sunrise) * 360 + 180}
+            rMin={radMax * 0}
+            rMax={radMax * 0.7}
+            className={"sCivilDusk"}
+          />
+        ) : undefined}
 
         {/* civil dusk to nautical dusk */}
-        {sunTimes !== null && config.showSunTimes
-          ? (
-            <Pie
-              cx={cx}
-              cy={cy}
-              angle1={dayPct(sunTimes.dusk) * 360 - 180}
-              angle2={dayPct(sunTimes.dawn) * 360 + 180}
-              rMin={radMax * 0}
-              rMax={radMax * 0.7}
-              style={sNauticalDusk}
-            />
-          )
-          : undefined}
+        {sunTimes !== null && config.showSunTimes ? (
+          <Pie
+            cx={cx}
+            cy={cy}
+            angle1={dayPct(sunTimes.dusk) * 360 - 180}
+            angle2={dayPct(sunTimes.dawn) * 360 + 180}
+            rMin={radMax * 0}
+            rMax={radMax * 0.7}
+            className={"sNauticalDusk"}
+          />
+        ) : undefined}
 
         {/* nautical dusk through night */}
-        {sunTimes !== null && config.showSunTimes
-          ? (
-            <Pie
-              cx={cx}
-              cy={cy}
-              angle1={dayPct(sunTimes.nauticalDusk) * 360 - 180}
-              angle2={dayPct(sunTimes.nauticalDawn) * 360 + 180}
-              rMin={radMax * 0}
-              rMax={radMax * 0.7}
-              style={sNight}
-            />
-          )
-          : undefined}
+        {sunTimes !== null && config.showSunTimes ? (
+          <Pie
+            cx={cx}
+            cy={cy}
+            angle1={dayPct(sunTimes.nauticalDusk) * 360 - 180}
+            angle2={dayPct(sunTimes.nauticalDawn) * 360 + 180}
+            rMin={radMax * 0}
+            rMax={radMax * 0.7}
+            className={"sNight"}
+          />
+        ) : undefined}
 
         {/* season hours and UTC labels */}
         <Rotate cx={cx} cy={cy} angle={((12 - hoursOffset) * 360) / 24}>
@@ -224,13 +213,13 @@ export default function App() {
             ticks={range(24).map((n) => {
               let hourOf = hourTable[n];
               // title case
-              let shortNameTitle = hourOf.shortName[0].toUpperCase() +
-                hourOf.shortName.slice(1);
+              let shortNameTitle =
+                hourOf.shortName[0].toUpperCase() + hourOf.shortName.slice(1);
               return {
                 angle: (360 * n) / 24,
                 text: shortNameTitle,
-                bgStyle: sFillSeasonLookup[hourOf.season],
-                cText: cInk,
+                className: sFillSeasonLookup[hourOf.season],
+                classNameText: "sFillInk"
               };
             })}
           />
@@ -244,26 +233,9 @@ export default function App() {
             ticks={range(24).map((n) => ({
               angle: (360 * n) / 24,
               text: "U " + ("" + n).padStart(2, "0"),
-              bgStyle: sNone,
-              cText: cInkFaint,
+              className: "sNone",
+              classNameText: "sFillInkFaint"
             }))}
-          />
-          <Dial
-            cx={cx}
-            cy={cy}
-            radMax={radMax * 1.01}
-            radMin={radMax * 0.9}
-            textAlign="center-range"
-            ticks={range(24).map((n) => {
-              let moji = hourTable[n].emoji;
-
-              return {
-                angle: (360 * n) / 24,
-                text: moji,
-                bgStyle: sNone,
-                cText: cInkFaint,
-              };
-            })}
           />
         </Rotate>
 
@@ -277,9 +249,9 @@ export default function App() {
           textScale={0.62}
           ticks={range(24).map((n) => ({
             angle: (360 * n) / 24,
-            text: hourToString(n),
-            bgStyle: sNone,
-            cText: cInk,
+            text: hourToString((n + 12) % 24),
+            className: "sNone",
+            classNameText: "sFillInk"
           }))}
         />
 
@@ -290,7 +262,7 @@ export default function App() {
             y1={cy + radMax * 0.5}
             x2={cx}
             y2={cy + radMax * 0.82}
-            style={sLineInk}
+            className={"sLineInk"}
           />
         </Rotate>
       </svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -161,7 +161,7 @@ export default function App() {
       hoursOffset = offset;
     }
   }
-  let nowDayPct = dayPct(now); // range: 0-1 (midnight to midnight)
+  let nowDayPct = dayPct(now, hoursOffset); // range: 0-1 (midnight to midnight)
   return (
     <div className="App">
       <svg width={config.res} height={config.res} style={sFillDebug}>
@@ -175,11 +175,54 @@ export default function App() {
           <Pie
             cx={cx}
             cy={cy}
-            angle1={dayPct(sunTimes.sunrise) * 360 + 180}
-            angle2={dayPct(sunTimes.sunset) * 360 + 180}
+            angle1={(dayPct(sunTimes.sunrise) + hoursOffset / 24) * 360 - 180}
+            angle2={(dayPct(sunTimes.sunset) + hoursOffset / 24) * 360 + 180}
             rMin={radMax * 0}
             rMax={radMax * 0.7}
             className={"sDay"}
+          />
+        ) : undefined}
+
+        {/* sunset to civil dusk */}
+        {sunTimes !== null && config.showSunTimes ? (
+          <Pie
+            cx={cx}
+            cy={cy}
+            angle1={(dayPct(sunTimes.sunset) + hoursOffset / 24) * 360 + 180}
+            angle2={(dayPct(sunTimes.sunrise) + hoursOffset / 24) * 360 + 180}
+            rMin={radMax * 0}
+            rMax={radMax * 0.7}
+            className={"sCivilDusk"}
+          />
+        ) : undefined}
+
+        {/* civil dusk to nautical dusk */}
+        {sunTimes !== null && config.showSunTimes ? (
+          <Pie
+            cx={cx}
+            cy={cy}
+            angle1={(dayPct(sunTimes.dusk) + hoursOffset / 24) * 360 + 180}
+            angle2={(dayPct(sunTimes.dawn) + hoursOffset / 24) * 360 + 180}
+            rMin={radMax * 0}
+            rMax={radMax * 0.7}
+            className={"sNauticalDusk"}
+          />
+        ) : undefined}
+
+        {/* nautical dusk through night */}
+        {sunTimes !== null && config.showSunTimes ? (
+          <Pie
+            cx={cx}
+            cy={cy}
+            angle1={
+              (dayPct(sunTimes.nauticalDusk) + hoursOffset / 24) * 360 + 180
+            }
+            angle2={
+              (dayPct(sunTimes.nauticalDawn) + hoursOffset / 24) * 360 + 180
+            }
+            rMin={radMax * 0}
+            rMax={radMax * 0.7}
+            className={"sNight"}
           />
         ) : undefined}
 
@@ -192,45 +235,6 @@ export default function App() {
             className={"sFillInk"}
           />
         </Rotate>
-
-        {/* sunset to civil dusk */}
-        {sunTimes !== null && config.showSunTimes ? (
-          <Pie
-            cx={cx}
-            cy={cy}
-            angle1={dayPct(sunTimes.sunset) * 360 - 180}
-            angle2={dayPct(sunTimes.sunrise) * 360 + 180}
-            rMin={radMax * 0}
-            rMax={radMax * 0.7}
-            className={"sCivilDusk"}
-          />
-        ) : undefined}
-
-        {/* civil dusk to nautical dusk */}
-        {sunTimes !== null && config.showSunTimes ? (
-          <Pie
-            cx={cx}
-            cy={cy}
-            angle1={dayPct(sunTimes.dusk) * 360 - 180}
-            angle2={dayPct(sunTimes.dawn) * 360 + 180}
-            rMin={radMax * 0}
-            rMax={radMax * 0.7}
-            className={"sNauticalDusk"}
-          />
-        ) : undefined}
-
-        {/* nautical dusk through night */}
-        {sunTimes !== null && config.showSunTimes ? (
-          <Pie
-            cx={cx}
-            cy={cy}
-            angle1={dayPct(sunTimes.nauticalDusk) * 360 - 180}
-            angle2={dayPct(sunTimes.nauticalDawn) * 360 + 180}
-            rMin={radMax * 0}
-            rMax={radMax * 0.7}
-            className={"sNight"}
-          />
-        ) : undefined}
 
         {/* season hours and UTC labels */}
         <Rotate cx={cx} cy={cy} angle={((12 - hoursOffset) * 360) / 24}>

--- a/src/dial.tsx
+++ b/src/dial.tsx
@@ -4,7 +4,6 @@ import {
     Rotate,
     Pie,
 } from './svg-utils';
-import { cInk } from "./styles";
 
 //================================================================================
 // MAIN
@@ -12,8 +11,8 @@ import { cInk } from "./styles";
 export interface Tick {
     angle: number,
     text?: string,
-    bgStyle?: React.CSSProperties,
-    cText?: string,
+    className?: string,
+    classNameText?: string,
 }
 interface DialProps {
     cx: number,
@@ -43,18 +42,14 @@ export let Dial = (props: DialProps) => {
                     angle1={tick.angle}
                     angle2={tick.angle + tickAngleWidth}
                     rMin={radMin} rMax={radMax}
-                    style={tick.bgStyle}
+                    className={tick.className}
                     />
                 <Rotate cx={cx} cy={cy} angle={tick.angle + textRotExtra}>
                     <text x={cx} y={cy - (radMin + radMax)/2}
                         textAnchor={textAlign === 'left' ? 'left' : 'middle'}
                         dominantBaseline="mathematical"
                         fontSize={(radMax - radMin) * (textScale as number)}
-                        style={{
-                            stroke: 'none',
-                            fill: tick.cText || cInk,
-                            //fontWeight: 'bold',
-                        }}
+                        className={tick.classNameText || 'sFillInk'}
                         >
                         {tick.text}
                     </text>

--- a/src/dial.tsx
+++ b/src/dial.tsx
@@ -1,60 +1,74 @@
 import * as React from "react";
 
-import {
-    Rotate,
-    Pie,
-} from './svg-utils';
+import { Rotate, Pie } from "./svg-utils";
 
 //================================================================================
 // MAIN
 
 export interface Tick {
-    angle: number,
-    text?: string,
-    className?: string,
-    classNameText?: string,
+  angle: number;
+  text?: string;
+  className?: string;
+  classNameText?: string;
 }
 interface DialProps {
-    cx: number,
-    cy: number,
-    radMin: number,
-    radMax: number,
-    ticks: Tick[],
-    textScale?: number, // default 0.6
-    textAlign: 'left' | 'center-line' | 'center-range',
+  cx: number;
+  cy: number;
+  radMin: number;
+  radMax: number;
+  ticks: Tick[];
+  textScale?: number; // default 0.6
+  textAlign: "left" | "center-line" | "center-range";
 }
 export let Dial = (props: DialProps) => {
-    let { cx, cy, radMin, radMax, ticks, textScale, textAlign } = props;
-    if (textScale === undefined) { textScale = 0.6; }
+  let { cx, cy, radMin, radMax, ticks, textScale, textAlign } = props;
+  if (textScale === undefined) {
+    textScale = 0.6;
+  }
 
-    let tickAngleWidth = 360 / ticks.length;
-    let textRotExtra =
-        textAlign === 'left' ? 1.5 :
-        textAlign === 'center-line' ? 0 :
-        textAlign === 'center-range' ? (tickAngleWidth/2) : 0;
-    return <>
-        {/* clock face */}
-        {/*<circle cx={cx} cy={cy} r={radMax} />*/}
+  let tickAngleWidth = 360 / ticks.length;
+  let textRotExtra =
+    textAlign === "left"
+      ? 1.5
+      : textAlign === "center-line"
+      ? 0
+      : textAlign === "center-range"
+      ? tickAngleWidth / 2
+      : 0;
+  return (
+    <>
+      {/* clock face */}
+      {/*<circle cx={cx} cy={cy} r={radMax} />*/}
 
-        {ticks.map(tick =>
-            <React.Fragment key={'dial|'+radMin+'|'+tick.angle}>
-                <Pie cx={cx} cy={cy}
-                    angle1={tick.angle}
-                    angle2={tick.angle + tickAngleWidth}
-                    rMin={radMin} rMax={radMax}
-                    className={tick.className}
-                    />
-                <Rotate cx={cx} cy={cy} angle={tick.angle + textRotExtra}>
-                    <text x={cx} y={cy - (radMin + radMax)/2}
-                        textAnchor={textAlign === 'left' ? 'left' : 'middle'}
-                        dominantBaseline="mathematical"
-                        fontSize={(radMax - radMin) * (textScale as number)}
-                        className={tick.classNameText || 'sFillInk'}
-                        >
-                        {tick.text}
-                    </text>
-                </Rotate>
-            </React.Fragment>
-        )}
-    </>;
-}
+      {ticks.map((tick) => (
+        <React.Fragment key={"dial|" + radMin + "|" + tick.angle}>
+          <Pie
+            cx={cx}
+            cy={cy}
+            angle1={tick.angle}
+            angle2={
+              tick.angle +
+              tickAngleWidth +
+              0.4 /* so that the background does not show between adjacent slices */
+            }
+            rMin={radMin}
+            rMax={radMax}
+            className={tick.className}
+          />
+          <Rotate cx={cx} cy={cy} angle={tick.angle + textRotExtra}>
+            <text
+              x={cx}
+              y={cy - (radMin + radMax) / 2}
+              textAnchor={textAlign === "left" ? "left" : "middle"}
+              dominantBaseline="mathematical"
+              fontSize={(radMax - radMin) * (textScale as number)}
+              className={tick.classNameText || "sFillInk"}
+            >
+              {tick.text}
+            </text>
+          </Rotate>
+        </React.Fragment>
+      ))}
+    </>
+  );
+};

--- a/src/dial.tsx
+++ b/src/dial.tsx
@@ -49,7 +49,7 @@ export let Dial = (props: DialProps) => {
             angle2={
               tick.angle +
               tickAngleWidth +
-              0.4 /* so that the background does not show between adjacent slices */
+              0.4 /* background does not show between adjacent slices */
             }
             rMin={radMin}
             rMax={radMax}

--- a/src/seasonal-hours.ts
+++ b/src/seasonal-hours.ts
@@ -23,136 +23,136 @@ export let hourTable: Record<number, HourOf> = {
     season: "winter",
     shortName: "candle",
     longName: "candle hour",
-    emoji: "🕯",
+    emoji: "🕯"
   },
   1: {
     season: "winter",
     shortName: "ice",
     longName: "hour of ice",
-    emoji: "❄️",
+    emoji: "❄️"
   },
   2: {
     season: "winter",
     shortName: "comet",
     longName: "hour of the comet",
-    emoji: "☄️",
+    emoji: "☄️"
   },
   3: { season: "winter", shortName: "owl", longName: "owl hour", emoji: "🦉" },
   4: {
     season: "winter",
     shortName: "yarn",
     longName: "yarn hour",
-    emoji: "🧶",
+    emoji: "🧶"
   },
   5: {
     season: "winter",
     shortName: "mist",
     longName: "hour of mist",
-    emoji: "🌫",
+    emoji: "🌫"
   },
   6: {
     season: "spring",
     shortName: "sprout",
     longName: "sprout hour",
-    emoji: "🌱",
+    emoji: "🌱"
   },
   7: {
     season: "spring",
     shortName: "rainbow",
     longName: "rainbow hour",
-    emoji: "🌈",
+    emoji: "🌈"
   },
   8: {
     season: "spring",
     shortName: "worm",
     longName: "worm hour",
-    emoji: "🪱",
+    emoji: "🪱"
   },
   9: {
     season: "spring",
     shortName: "rabbit",
     longName: "rabbit hour",
-    emoji: "🐇",
+    emoji: "🐇"
   },
   10: {
     season: "spring",
     shortName: "blossom",
     longName: "blossom hour",
-    emoji: "🌸",
+    emoji: "🌸"
   },
   11: {
     season: "spring",
     shortName: "nest",
     longName: "nest hour",
-    emoji: "🪺",
+    emoji: "🪺"
   },
   12: {
     season: "summer",
     shortName: "coral",
     longName: "coral hour",
-    emoji: "🪸",
+    emoji: "🪸"
   },
   13: {
     season: "summer",
     shortName: "cherry",
     longName: "cherry hour",
-    emoji: "🍒",
+    emoji: "🍒"
   },
   14: { season: "summer", shortName: "bee", longName: "bee hour", emoji: "🐝" },
   15: {
     season: "summer",
     shortName: "melon",
     longName: "melon hour",
-    emoji: "🍉",
+    emoji: "🍉"
   },
   16: {
     season: "summer",
     shortName: "seashell",
     longName: "seashell hour",
-    emoji: "🐚",
+    emoji: "🐚"
   },
   17: {
     season: "summer",
     shortName: "dragon",
     longName: "hour of the dragon",
-    emoji: "🐉",
+    emoji: "🐉"
   },
   18: {
     season: "autumn",
     shortName: "chestnut",
     longName: "chestnut hour",
-    emoji: "🌰",
+    emoji: "🌰"
   },
   19: {
     season: "autumn",
     shortName: "kite",
     longName: "hour of the kite",
-    emoji: "🪁",
+    emoji: "🪁"
   },
   20: {
     season: "autumn",
     shortName: "mushroom",
     longName: "mushroom hour",
-    emoji: "🍄",
+    emoji: "🍄"
   },
   21: {
     season: "autumn",
     shortName: "lightning",
     longName: "lightning hour",
-    emoji: "⚡️",
+    emoji: "⚡️"
   },
   22: {
     season: "autumn",
     shortName: "mountain",
     longName: "hour of the mountain",
-    emoji: "⛰",
+    emoji: "⛰"
   },
   23: {
     season: "autumn",
     shortName: "lantern",
     longName: "lantern hour",
-    emoji: "🏮",
-  },
+    emoji: "🏮"
+  }
 };
 
 export let getUtcHour = (): number => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,6 +2,7 @@
   --cPage: rgb(0, 0, 0);
   --cInk: #eb5;
   --cInkFaint: rgb(91, 68, 38);
+  --cInkHighlight: rgb(255, 211, 123);
 }
 
 @media (prefers-color-scheme: light) {
@@ -9,6 +10,7 @@
     --cPage: rgb(235, 239, 252);
     --cInk: rgb(189, 126, 0);
     --cInkFaint: rgb(218, 184, 139);
+    --cInkHighlight: rgb(175, 129, 2);
   }
 }
 
@@ -24,7 +26,7 @@ a {
 
 @media (prefers-color-scheme: light) {
   a {
-    color: rgb(219, 219, 219);
+    color: rgb(207, 207, 207);
   }
 }
 
@@ -104,7 +106,37 @@ a {
   fill: rgb(70, 62, 108);
 }
 
+.sNone.sHighlight {
+  fill: rgb(65, 31, 65);
+}
 
+.sFillInk.sHighlight {
+  fill: var(--cInkHighlight);
+}
+
+.sFillSpring.sHighlight {
+  stroke: var(--cPage);
+  stroke-width: 2;
+  fill: rgb(95, 139, 95);
+}
+
+.sFillSummer.sHighlight {
+  stroke: var(--cPage);
+  stroke-width: 2;
+  fill: rgb(156, 129, 64);
+}
+
+.sFillAutumn.sHighlight {
+  stroke: var(--cPage);
+  stroke-width: 2;
+  fill: rgb(161, 107, 73);
+}
+
+.sFillWinter.sHighlight {
+  stroke: var(--cPage);
+  stroke-width: 2;
+  fill: rgb(108, 96, 163);
+}
 
 @media (prefers-color-scheme: light) {
   .sDay {
@@ -170,5 +202,37 @@ a {
     stroke: var(--cPage);
     stroke-width: 2;
     fill: rgb(215, 209, 248);
+  }
+
+  .sNone.sHighlight {
+    fill: rgb(255, 202, 228);
+  }
+
+  .sFillInk.sHighlight {
+    fill: var(--cInkHighlight);
+  }
+
+  .sFillSpring.sHighlight {
+    stroke: var(--cPage);
+    stroke-width: 2;
+    fill: rgb(145, 225, 145);
+  }
+
+  .sFillSummer.sHighlight {
+    stroke: var(--cPage);
+    stroke-width: 2;
+    fill: rgb(233, 196, 111);
+  }
+
+  .sFillAutumn.sHighlight {
+    stroke: var(--cPage);
+    stroke-width: 2;
+    fill: rgb(230, 183, 172);
+  }
+
+  .sFillWinter.sHighlight {
+    stroke: var(--cPage);
+    stroke-width: 2;
+    fill: rgb(188, 177, 248);
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,5 +1,174 @@
+:root {
+  --cPage: rgb(0, 0, 0);
+  --cInk: #eb5;
+  --cInkFaint: rgb(91, 68, 38);
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --cPage: rgb(235, 239, 252);
+    --cInk: rgb(189, 126, 0);
+    --cInkFaint: rgb(218, 184, 139);
+  }
+}
+
+body {
+  background-color: var(--cPage);
+  color: var(--cInk);
+}
+
+a {
+  color: #333;
+  text-decoration: none;
+}
+
+@media (prefers-color-scheme: light) {
+  a {
+    color: rgb(219, 219, 219);
+  }
+}
+
+.github-link {
+  position: fixed;
+  top: 10px;
+  left: 10px;
+}
 
 .App {
   font-family: sans-serif;
   text-align: center;
+}
+
+.sDay {
+  stroke: none;
+  fill: rgb(113, 92, 43);
+}
+
+.sCivilDusk {
+  stroke: none;
+  fill: rgb(99, 38, 53);
+}
+
+.sNauticalDusk {
+  stroke: none;
+  fill: rgb(39, 38, 53);
+}
+
+.sNight {
+  stroke: none;
+  fill: rgb(19, 17, 30);
+}
+
+.sNone {
+  stroke: none;
+  fill: none;
+}
+
+.sLineInk {
+  stroke: var(--cInk);
+  fill: none;
+  stroke-width: 2;
+}
+
+.sFillInk {
+  stroke: none;
+  fill: var(--cInk);
+}
+
+.sFillInkFaint {
+  stroke: none;
+  fill: var(--cInkFaint);
+}
+
+.sFillSpring {
+  stroke: var(--cPage);
+  stroke-width: 2;
+  fill: rgb(55, 87, 55);
+}
+
+.sFillSummer {
+  stroke: var(--cPage);
+  stroke-width: 2;
+  fill: rgb(113, 92, 43);
+}
+
+.sFillAutumn {
+  stroke: var(--cPage);
+  stroke-width: 2;
+  fill: rgb(108, 68, 44);
+}
+
+.sFillWinter {
+  stroke: var(--cPage);
+  stroke-width: 2;
+  fill: rgb(70, 62, 108);
+}
+
+
+
+@media (prefers-color-scheme: light) {
+  .sDay {
+    stroke: none;
+    fill: rgb(245, 218, 157);
+  }
+
+  .sCivilDusk {
+    stroke: none;
+    fill: rgb(240, 133, 160);
+  }
+
+  .sNauticalDusk {
+    stroke: none;
+    fill: rgb(123, 119, 177);
+  }
+
+  .sNight {
+    stroke: none;
+    fill: rgb(79, 73, 119);
+  }
+
+  .sNone {
+    stroke: none;
+    fill: none;
+  }
+
+  .sLineInk {
+    stroke: var(--cInk);
+    fill: none;
+    stroke-width: 2;
+  }
+
+  .sFillInk {
+    stroke: none;
+    fill: var(--cInk);
+  }
+
+  .sFillInkFaint {
+    stroke: none;
+    fill: var(--cInkFaint);
+  }
+
+  .sFillSpring {
+    stroke: var(--cPage);
+    stroke-width: 2;
+    fill: rgb(197, 235, 197);
+  }
+
+  .sFillSummer {
+    stroke: var(--cPage);
+    stroke-width: 2;
+    fill: rgb(241, 222, 177);
+  }
+
+  .sFillAutumn {
+    stroke: var(--cPage);
+    stroke-width: 2;
+    fill: rgb(247, 222, 216);
+  }
+
+  .sFillWinter {
+    stroke: var(--cPage);
+    stroke-width: 2;
+    fill: rgb(215, 209, 248);
+  }
 }

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,82 +1,22 @@
 import * as React from "react";
-import { config } from './config';
+import { config } from "./config";
 import { Season } from "./seasonal-hours";
 
-//================================================================================
-// COLORS
-
-export let cPage = 'black';
-export let cInk = '#eb5';  // gold
-export let cInkFaint = 'rgb(91, 68, 38)';
-
-//================================================================================
-// STYLES
-
-export let sDay: React.CSSProperties = {
-    stroke: 'none',
-    fill: 'rgb(113, 92, 43)',
-};
-export let sCivilDusk: React.CSSProperties = {
-    stroke: 'none',
-    fill: 'rgb(99, 38, 53)',
-};
-export let sNauticalDusk: React.CSSProperties = {
-    stroke: 'none',
-    fill: 'rgb(39, 38, 53)',
-};
-export let sNight: React.CSSProperties = {
-    stroke: 'none',
-    fill: 'rgb(19, 17, 30)',
-};
-
-export let sNone: React.CSSProperties = {
-    stroke: 'none',
-    fill: 'none',
-};
-export let sLineInk: React.CSSProperties = {
-    stroke: cInk,
-    fill: 'none',
-    strokeWidth: 2,
-};
 export let sLineDebug: React.CSSProperties = {
-    stroke: config.showDebug ? '#080' : 'none',
-    fill: 'none',
+  stroke: config.showDebug ? "#080" : "none",
+  fill: "none"
 };
 export let sFillDebug: React.CSSProperties = {
-    stroke: cInk,
-    fill: config.showDebug ? 'rgba(0,128,0,0.3)' : 'none',
-};
-export let sFillInk: React.CSSProperties = {
-    stroke: 'none',
-    fill: cInk,
+  stroke: "#eb5",
+  fill: config.showDebug ? "rgba(0,128,0,0.3)" : "none"
 };
 
 //================================================================================
 // SEASONAL BACKGROUND STYLES
 
-let sSeasonBase: React.CSSProperties = {
-    stroke: cPage,
-    strokeWidth: 2,
-}
-export let sFillSpring: React.CSSProperties = {
-    ...sSeasonBase,
-    fill: 'rgb(55, 87, 55)',
-}
-export let sFillSummer: React.CSSProperties = {
-    ...sSeasonBase,
-    fill: 'rgb(113, 92, 43)',
-}
-export let sFillAutumn: React.CSSProperties = {
-    ...sSeasonBase,
-    fill: 'rgb(108, 68, 44)',
-}
-export let sFillWinter: React.CSSProperties = {
-    ...sSeasonBase,
-    fill: 'rgb(70, 62, 108)',
-}
-export let sFillSeasonLookup: Record<Season, React.CSSProperties> = {
-    'spring': sFillSpring,
-    'summer': sFillSummer,
-    'autumn': sFillAutumn,
-    'winter': sFillWinter,
-}
+export let sFillSeasonLookup: Record<Season, string> = {
+  spring: "sFillSpring",
+  summer: "sFillSummer",
+  autumn: "sFillAutumn",
+  winter: "sFillWinter"
+};

--- a/src/svg-utils.tsx
+++ b/src/svg-utils.tsx
@@ -99,6 +99,13 @@ export let Pie = ({
   let outerPoints: number[][] = [];
   let innerPoints: number[][] = [];
 
+  if (angle2 - angle1 > 360) {
+    angle1 += 360;
+  }
+  while (angle2 < angle1) {
+    angle2 += 360;
+  }
+
   let pointEveryNDegrees = 3;
   let n =
     Math.max(1, Math.ceil(Math.abs(angle1 - angle2) / pointEveryNDegrees)) + 1;

--- a/src/svg-utils.tsx
+++ b/src/svg-utils.tsx
@@ -1,116 +1,136 @@
 import * as React from "react";
-import {
-    interp,
-} from './util';
+import { interp } from "./util";
 
 //================================================================================
 
 // rectangle with center point
 interface RecProps {
-    cx: number,
-    cy: number,
-    rx: number,
-    ry?: number,
-    style?: React.CSSProperties,
+  cx: number;
+  cy: number;
+  rx: number;
+  ry?: number;
+  style?: React.CSSProperties;
+  className?: string;
 }
-export let Rec = ({cx, cy, rx, ry, style}: RecProps) => {
-    if (ry === undefined) { ry = rx; }
-    return <rect x={cx-rx} y={cy-ry}
-        width={rx*2} height={ry*2}
-        style={style}
+export let Rec = ({ cx, cy, rx, ry, style, className }: RecProps) => {
+  if (ry === undefined) {
+    ry = rx;
+  }
+  return (
+    <rect
+      x={cx - rx}
+      y={cy - ry}
+      width={rx * 2}
+      height={ry * 2}
+      style={style}
+      className={className}
     />
-}
+  );
+};
 
 //================================================================================
 
 // rotate around a given center point
 // positive angle in degrees is clockwise
 interface RotateProps {
-    cx: number,
-    cy: number,
-    angle: number,
+  cx: number;
+  cy: number;
+  angle: number;
 }
 export let Rotate = (props: React.PropsWithChildren<RotateProps>) => {
-    let { cx, cy, angle } = props;
-    let transformString = [
-        `translate(${cx} ${cy})`,
-        `rotate(${angle})`,
-        `translate(${-cx} ${-cy})`,
-    ].join(' ');
-    return <g transform={transformString}>
-        {props.children}
-    </g>;
-}
+  let { cx, cy, angle } = props;
+  let transformString = [
+    `translate(${cx} ${cy})`,
+    `rotate(${angle})`,
+    `translate(${-cx} ${-cy})`
+  ].join(" ");
+  return <g transform={transformString}>{props.children}</g>;
+};
 
 //================================================================================
 
-let pointsToSvgPathString = (points: number[][], closed: 'closed' | 'open'): string => {
-    let result = [];
-    let ii = 0
-    for (let [x,y] of points) {
-        if (ii === 0) {
-            result.push(`M ${x} ${y}`);
-        } else {
-            result.push(`L ${x} ${y}`);
-        }
-        ii += 1;
+let pointsToSvgPathString = (
+  points: number[][],
+  closed: "closed" | "open"
+): string => {
+  let result = [];
+  let ii = 0;
+  for (let [x, y] of points) {
+    if (ii === 0) {
+      result.push(`M ${x} ${y}`);
+    } else {
+      result.push(`L ${x} ${y}`);
     }
-    if (closed === 'closed') {
-        result.push('Z');
-    }
-    return result.join(' ');
-}
+    ii += 1;
+  }
+  if (closed === "closed") {
+    result.push("Z");
+  }
+  return result.join(" ");
+};
 
 interface PieProps {
-    // a pie slice or annular ring, as a polygon.
-    // inner radius is optional and defaults to 0
-    // for a traditional pie slice shape.
-    // angles are in degrees.
-    // 0 is up, positive is clockwise.
-    // if angle1 is 0 and angle2 is 360, this makes a hollow ring.
-    cx: number,
-    cy: number,
-    angle1: number,
-    angle2: number,
-    rMin?: number, // inner rad
-    rMax: number,
-    style?: React.CSSProperties,
+  // a pie slice or annular ring, as a polygon.
+  // inner radius is optional and defaults to 0
+  // for a traditional pie slice shape.
+  // angles are in degrees.
+  // 0 is up, positive is clockwise.
+  // if angle1 is 0 and angle2 is 360, this makes a hollow ring.
+  cx: number;
+  cy: number;
+  angle1: number;
+  angle2: number;
+  rMin?: number; // inner rad
+  rMax: number;
+  style?: React.CSSProperties;
+  className?: string;
 }
-export let Pie = ({ cx, cy, angle1, angle2, rMin, rMax, style }: PieProps) => {
-    rMin = rMin === undefined ? 0 : rMin;
-    let outerPoints: number[][] = [];
-    let innerPoints: number[][] = [];
+export let Pie = ({
+  cx,
+  cy,
+  angle1,
+  angle2,
+  rMin,
+  rMax,
+  style,
+  className
+}: PieProps) => {
+  rMin = rMin === undefined ? 0 : rMin;
+  let outerPoints: number[][] = [];
+  let innerPoints: number[][] = [];
 
-    let pointEveryNDegrees = 3;
-    let n = Math.max(1, Math.ceil(Math.abs(angle1-angle2) / pointEveryNDegrees)) + 1;
-    for (let ii = 0; ii < n; ii++) {
-        let tt = ii / (n-1);
-        let angle = interp(angle1, angle2, tt);
-        let x = Math.sin(angle * Math.PI/180);
-        let y = -Math.cos(angle * Math.PI/180);
-        outerPoints.push([cx + x * rMax, cy + y * rMax]);
-        innerPoints.push([cx + x * rMin, cy + y * rMin]);
-    }
-    let points: number[][];
-    let pathString = '';
-    if (angle1 === 0 && angle2 === 360) {
-        // hollow ring
-        innerPoints.reverse();
-        pathString = pointsToSvgPathString(outerPoints, 'closed')
-            + pointsToSvgPathString(innerPoints, 'closed');
+  let pointEveryNDegrees = 3;
+  let n =
+    Math.max(1, Math.ceil(Math.abs(angle1 - angle2) / pointEveryNDegrees)) + 1;
+  for (let ii = 0; ii < n; ii++) {
+    let tt = ii / (n - 1);
+    let angle = interp(angle1, angle2, tt);
+    let x = Math.sin((angle * Math.PI) / 180);
+    let y = -Math.cos((angle * Math.PI) / 180);
+    outerPoints.push([cx + x * rMax, cy + y * rMax]);
+    innerPoints.push([cx + x * rMin, cy + y * rMin]);
+  }
+  let points: number[][];
+  let pathString = "";
+  if (angle1 === 0 && angle2 === 360) {
+    // hollow ring
+    innerPoints.reverse();
+    pathString =
+      pointsToSvgPathString(outerPoints, "closed") +
+      pointsToSvgPathString(innerPoints, "closed");
+  } else {
+    if (rMin === 0) {
+      // pointy pie slice
+      points = outerPoints;
+      points.push([cx, cy]);
     } else {
-        if (rMin === 0) {
-            // pointy pie slice
-            points = outerPoints;
-            points.push([cx, cy]);
-        } else {
-            // pie slice outer ring shape
-            innerPoints.reverse();
-            points = outerPoints.concat(innerPoints);
-        }
-        pathString = pointsToSvgPathString(points, 'closed');
+      // pie slice outer ring shape
+      innerPoints.reverse();
+      points = outerPoints.concat(innerPoints);
     }
+    pathString = pointsToSvgPathString(points, "closed");
+  }
 
-    //let pointsString = points.map(([x, y]) => `${x}, ${y}`).join(' ');
-    return <path style={style} d={pathString}/>
-}
+  //let pointsString = points.map(([x, y]) => `${x}, ${y}`).join(' ');
+  return <path className={className} style={style} d={pathString} />;
+};

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -1,19 +1,25 @@
-
 //================================================================================
 // HELPERS
 
 // a function that does nothing
 // this helps satisfy the linter that a variable is being used
-export let nop = (x: any): void => {}
+export let nop = (x: any): void => {};
 
 // given a date, return the fraction of the way it is through the day
-// from midnight to midnight, range 0-1.
-export let dayPct = (date: Date): number =>
-    date.getHours() / 24 + date.getMinutes() / 24 / 60 + date.getSeconds() / 24 / 60 / 60;
+// from midnight to midnight, range 0-1, in utc.
+export let dayPct = (date: Date): number => {
+  return (
+    date.getUTCHours() / 24 +
+    date.getUTCMinutes() / 24 / 60 +
+    date.getUTCSeconds() / 24 / 60 / 60
+  );
+};
 
 export let interp = (a: number, b: number, tt: number): number =>
-    a + (b-a) * tt;
+  a + (b - a) * tt;
 
 // array from 0 to n-1
 export let range = (n: number): number[] =>
-    Array(n).fill(0).map((x, ii) => ii);
+  Array(n)
+    .fill(0)
+    .map((x, ii) => ii);


### PR DESCRIPTION
Changes ~~all~~ most styling to be css class-based, and then adds a light color scheme. Color scheme is selected via `@media (prefers-color-scheme: light)` media queries.

~~This is a fork of the original code base, so it undoes the emoji addition and hour changes. Needs manual merging for that reason.~~ See next comment.