### PR TITLE
Fix emoji display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -315,7 +315,7 @@ export default function App() {
                 className: `sNone ${
                   highlighted_hours.has(n) ? "sHighlight" : ""
                 }`,
-                classNameText: "sFillInkFaint"
+                classNameText: "iconText"
               };
             })}
           />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -307,7 +307,7 @@ export default function App() {
             //radMin={radMax * 0.705} // dont forget to fix highlighted backgrounds then
             textAlign="center-range"
             ticks={range(24).map((n) => {
-              let moji = hourTable[n].emoji;
+              let moji = `${hourTable[n].emoji}\uFE0F`;
 
               return {
                 angle: (360 * n) / 24,

--- a/src/seasonal-hours.ts
+++ b/src/seasonal-hours.ts
@@ -23,7 +23,7 @@ export let hourTable: Record<number, HourOf> = {
     season: "winter",
     shortName: "candle",
     longName: "candle hour",
-    emoji: "🕯"
+    emoji: "🕯️"
   },
   1: {
     season: "winter",
@@ -48,7 +48,7 @@ export let hourTable: Record<number, HourOf> = {
     season: "winter",
     shortName: "mist",
     longName: "hour of mist",
-    emoji: "🌫"
+    emoji: "🌫️"
   },
   6: {
     season: "spring",
@@ -145,7 +145,7 @@ export let hourTable: Record<number, HourOf> = {
     season: "autumn",
     shortName: "mountain",
     longName: "hour of the mountain",
-    emoji: "⛰"
+    emoji: "⛰️"
   },
   23: {
     season: "autumn",

--- a/src/styles.css
+++ b/src/styles.css
@@ -106,6 +106,11 @@ a {
   fill: rgb(70, 62, 108);
 }
 
+.iconText {
+  stroke: rgb(252, 243, 195);
+  fill: var(--cInkFaint);
+}
+
 .sNone.sHighlight {
   fill: rgb(65, 31, 65);
 }
@@ -202,6 +207,11 @@ a {
     stroke: var(--cPage);
     stroke-width: 2;
     fill: rgb(215, 209, 248);
+  }
+
+  .iconText {
+    stroke: rgb(199, 168, 28);
+    fill: var(--cInkFaint);
   }
 
   .sNone.sHighlight {

--- a/src/styles.css
+++ b/src/styles.css
@@ -107,8 +107,7 @@ a {
 }
 
 .iconText {
-  stroke: rgb(252, 243, 195);
-  fill: var(--cInkFaint);
+  font-variant-emoji: emoji;
 }
 
 .sNone.sHighlight {
@@ -207,11 +206,6 @@ a {
     stroke: var(--cPage);
     stroke-width: 2;
     fill: rgb(215, 209, 248);
-  }
-
-  .iconText {
-    stroke: rgb(199, 168, 28);
-    fill: var(--cInkFaint);
   }
 
   .sNone.sHighlight {


### PR DESCRIPTION
This adds a class to the svg text elements that contain the emoji. Also adds default styling so that emoji whose color is controlled via svg styling are clearly visible now. For example, this improves appearance of the fog, candle and mountain emoji on windows.

This also opens the option of using custom icon fonts for integrating non-emoji hours for forks.