### PR TITLE
Resize request animation frame

### DIFF
--- a/src/circular-clock.tsx
+++ b/src/circular-clock.tsx
@@ -128,7 +128,7 @@ export default function CircularClock({
   };
 
   const determine_highlighting = (hour: number) => {
-    console.log(`r: ${radius}; threshold: ${show_utc_radius}`);
+    // console.log(`r: ${radius}; threshold: ${show_utc_radius}`);
 
     if (highlighted_hours.has(hour)) {
       if (radius >= show_utc_radius) {

--- a/src/resizer.tsx
+++ b/src/resizer.tsx
@@ -13,10 +13,12 @@ export default function Resizer({ children }: { children: React.ReactNode }) {
 
   React.useEffect(() => {
     const handleResize = () => {
-      setDimensions({
-        height: window.innerHeight,
-        width: window.innerWidth
-      });
+       requestAnimationFrame(() => {
+        setDimensions({
+          height: window.innerHeight,
+          width: window.innerWidth
+        });
+       });
     };
 
     window.addEventListener("resize", handleResize);

--- a/src/styles.css
+++ b/src/styles.css
@@ -39,7 +39,9 @@ a {
 .App {
   font-family: sans-serif;
   text-align: center;
+  transform: translate3d(0, 0, 0);
 }
+
 
 .sDay {
   stroke: none;


### PR DESCRIPTION
Calls `requestAnimationFrame` around the dimensions state update whenever the resize callback is fired. Should improve resizing speed somewhat, though it's not quite what I'd hoped for...

Which is why I've also added `transform: translate3d(0, 0, 0)` to the `.App` class' CSS. The presence of this rule makes many browsers switch to using the GPU for rendering.