### PR TITLE
Allow rotating the full clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ You can specify an offset from utc in the url to override the time displayed in 
 - Berlin in summer (latitude 52.31 degrees, longitude 13.24 degrees, UTC+2): [`https://seasonalclock.org/?lat=52.31&lon=13.24&offset=2`](https://seasonalclock.org/?lat=52.31&lon=13.24&offset=2)
 - Wellington (latitude -41.17 degrees, longitude 174.46 degrees, UTC+12): [`https://seasonalclock.org/?lat=-41.17&lon=174.46&offset=12`](https://seasonalclock.org/?lat=-41.17&lon=174.46&offset=12)
 
+You can rotate the full display by adding a search parameter of the form `rotate=<degrees_as_float>` to the url. By default, noon is at the top of the screen, but setting the rotation to `180` moves midnight to the top: [`https://seasonalclock.org/?rotate=180`](https://seasonalclock.org/?rotate=180)
+
 ---
 
 [seasonal-hours.ts](https://github.com/sgwilym/seasonal-hours-clock/blob/main/src/seasonal-hours.ts)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can specify an offset from utc in the url to override the time displayed in 
 - Berlin in summer (latitude 52.31 degrees, longitude 13.24 degrees, UTC+2): [`https://seasonalclock.org/?lat=52.31&lon=13.24&offset=2`](https://seasonalclock.org/?lat=52.31&lon=13.24&offset=2)
 - Wellington (latitude -41.17 degrees, longitude 174.46 degrees, UTC+12): [`https://seasonalclock.org/?lat=-41.17&lon=174.46&offset=12`](https://seasonalclock.org/?lat=-41.17&lon=174.46&offset=12)
 
-You can rotate the full display by adding a search parameter of the form `rotate=<degrees_as_float>` to the url. By default, noon is at the top of the screen, but setting the rotation to `180` moves midnight to the top: [`https://seasonalclock.org/?rotate=180`](https://seasonalclock.org/?rotate=180)
+You can rotate the full display by adding a search parameter of the form `rotate=<hours>` to the url. By default, noon is at the top of the screen, but setting the rotation to `12` moves midnight to the top: [`https://seasonalclock.org/?rotate=180`](https://seasonalclock.org/?rotate=12)
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,6 +105,12 @@ function get_highlighted_hours(url: URL): Set<number> {
 
 const highlighted_hours = get_highlighted_hours(url);
 
+const rotate_string = url.searchParams.get("rotate");
+let rotate = rotate_string ? parseFloat(rotate_string) : NaN;
+if (Number.isNaN(rotate)) {
+  rotate = 0;
+}
+
 let now = new Date();
 let hoursOffset = (-1 * now.getTimezoneOffset()) / 60;
 const offset_string = url.searchParams.get("offset");
@@ -133,6 +139,7 @@ export default function App() {
             loc={loc}
             highlighted_hours={highlighted_hours}
             hourTable={hourTable}
+            rotate={rotate}
           />
         </NowUpdater>
         <RepoLink />

--- a/src/circular-clock.tsx
+++ b/src/circular-clock.tsx
@@ -31,7 +31,8 @@ export default function CircularClock({
   time,
   sun_hours,
   highlighted_hours,
-  hourTable
+  hourTable,
+  rotate
 }: ClockUiProps) {
   const radius = Math.min(width, height) / 2;
   const cx = width / 2;
@@ -204,132 +205,134 @@ export default function CircularClock({
 
   return (
     <svg width={width} height={height}>
-      {/* everything in here is calculated based on utc */}
-      {/* and must be rotated according to the offset to utc */}
-      {radius >= give_up_radius && (
-        <Rotate cx={cx} cy={cy} angle={time_to_angle(utc_offset)}>
-          {sun_hours_display}
-          {/* highlighted background */}
-          <Dial
-            cx={cx}
-            cy={cy}
-            radMax={highlight_annulus_end}
-            radMin={highlight_annulus_start}
-            textAlign="center-line"
-            ticks={range(24).map((n) => ({
-              angle: (360 * n) / 24,
-              text: "",
-              className: `sNone ${determine_highlighting(n)}`,
-              classNameText: ""
-            }))}
-          />
-          {/* hour hand */}
-          <Rotate cx={cx} cy={cy} angle={time_to_angle(time)}>
-            {/* sun */}
-            <circle
+      <Rotate cx={cx} cy={cy} angle={rotate}>
+        {/* everything in here is calculated based on utc */}
+        {/* and must be rotated according to the offset to utc */}
+        {radius >= give_up_radius && (
+          <Rotate cx={cx} cy={cy} angle={time_to_angle(utc_offset)}>
+            {sun_hours_display}
+            {/* highlighted background */}
+            <Dial
               cx={cx}
-              cy={cy + sun_distance}
-              r={sun_radius}
-              className={"sFillInk"}
-            />
-
-            {/* line of hour hand */}
-            <line
-              x1={cx}
-              y1={cy + sun_distance}
-              x2={cx}
-              y2={cy + hour_hand_tip}
-              className={"sLineInk"}
-            />
-          </Rotate>
-          {/* main hour displays */}
-          <Dial
-            cx={cx}
-            cy={cy}
-            radMax={main_annulus_end}
-            radMin={main_annulus_start}
-            textAlign="center-range"
-            textScale={main_scale}
-            dominantBaseline={
-              radius >= show_names_radius ? "mathematical" : "central"
-            }
-            ticks={range(24).map((n) => {
-              let hourOf = hourTable[n];
-              const label =
-                radius >= show_names_radius
-                  ? `${hourOf.shortName[0].toUpperCase()}${hourOf.shortName.slice(
-                      1
-                    )}`
-                  : `${hourOf.emoji}\uFE0F`;
-
-              return {
+              cy={cy}
+              radMax={highlight_annulus_end}
+              radMin={highlight_annulus_start}
+              textAlign="center-line"
+              ticks={range(24).map((n) => ({
                 angle: (360 * n) / 24,
-                text: label,
-                className: `${
-                  sFillSeasonLookup[hourOf.season]
-                } ${determine_highlighting(n)}`,
-                classNameText: `sFillInk ${determine_highlighting(n)}`
-              };
-            })}
-          />
-          {/* utc time */}
-          <Dial
-            cx={cx}
-            cy={cy}
-            radMax={outer_annulus_end}
-            radMin={outer_annulus_start}
-            textAlign="center-line"
-            textScale={outer_scale}
-            ticks={range(24).map((n) => ({
-              angle: (360 * n) / 24,
-              text: `U ${("" + n).padStart(2, "0")}`,
-              className: "sNone",
-              classNameText: "sFillInkFaint"
-            }))}
-          />
-          {/* emoji on outer ring */}
-          {radius >= show_names_radius && (
+                text: "",
+                className: `sNone ${determine_highlighting(n)}`,
+                classNameText: ""
+              }))}
+            />
+            {/* hour hand */}
+            <Rotate cx={cx} cy={cy} angle={time_to_angle(time)}>
+              {/* sun */}
+              <circle
+                cx={cx}
+                cy={cy + sun_distance}
+                r={sun_radius}
+                className={"sFillInk"}
+              />
+
+              {/* line of hour hand */}
+              <line
+                x1={cx}
+                y1={cy + sun_distance}
+                x2={cx}
+                y2={cy + hour_hand_tip}
+                className={"sLineInk"}
+              />
+            </Rotate>
+            {/* main hour displays */}
+            <Dial
+              cx={cx}
+              cy={cy}
+              radMax={main_annulus_end}
+              radMin={main_annulus_start}
+              textAlign="center-range"
+              textScale={main_scale}
+              dominantBaseline={
+                radius >= show_names_radius ? "mathematical" : "central"
+              }
+              ticks={range(24).map((n) => {
+                let hourOf = hourTable[n];
+                const label =
+                  radius >= show_names_radius
+                    ? `${hourOf.shortName[0].toUpperCase()}${hourOf.shortName.slice(
+                        1
+                      )}`
+                    : `${hourOf.emoji}\uFE0F`;
+
+                return {
+                  angle: (360 * n) / 24,
+                  text: label,
+                  className: `${
+                    sFillSeasonLookup[hourOf.season]
+                  } ${determine_highlighting(n)}`,
+                  classNameText: `sFillInk ${determine_highlighting(n)}`
+                };
+              })}
+            />
+            {/* utc time */}
             <Dial
               cx={cx}
               cy={cy}
               radMax={outer_annulus_end}
               radMin={outer_annulus_start}
               textAlign="center-line"
-              textScale={outer_emoji_scale}
-              dominantBaseline="text-top"
+              textScale={outer_scale}
               ticks={range(24).map((n) => ({
-                angle: (360 * (n + 0.5)) / 24,
-                text: `${hourTable[n].emoji}\uFE0F`,
+                angle: (360 * n) / 24,
+                text: `U ${("" + n).padStart(2, "0")}`,
                 className: "sNone",
                 classNameText: "sFillInkFaint"
               }))}
             />
-          )}
-        </Rotate>
-      )}
+            {/* emoji on outer ring */}
+            {radius >= show_names_radius && (
+              <Dial
+                cx={cx}
+                cy={cy}
+                radMax={outer_annulus_end}
+                radMin={outer_annulus_start}
+                textAlign="center-line"
+                textScale={outer_emoji_scale}
+                dominantBaseline="text-top"
+                ticks={range(24).map((n) => ({
+                  angle: (360 * (n + 0.5)) / 24,
+                  text: `${hourTable[n].emoji}\uFE0F`,
+                  className: "sNone",
+                  classNameText: "sFillInkFaint"
+                }))}
+              />
+            )}
+          </Rotate>
+        )}
 
-      {/* local time */}
-      {radius >= give_up_radius && (
-        <Dial
-          cx={cx}
-          cy={cy}
-          radMax={inner_annulus_end}
-          radMin={inner_annulus_start}
-          textAlign="center-line"
-          textScale={inner_scale} // overwritten by fontSize
-          fontSize={Math.max(
-            (inner_annulus_end - inner_annulus_start) * inner_scale,
-            11.2
-          )}
-          ticks={range(24).map((n) => ({
-            angle: (360 * n) / 24 + 540,
-            text:
-              n % show_local_times_divisible_by === 0 ? hourToString(n) : ".",
-            className: "sNone",
-            classNameText: "sFillInk"
-          }))}
-        />
-      )}
+        {/* local time */}
+        {radius >= give_up_radius && (
+          <Dial
+            cx={cx}
+            cy={cy}
+            radMax={inner_annulus_end}
+            radMin={inner_annulus_start}
+            textAlign="center-line"
+            textScale={inner_scale} // overwritten by fontSize
+            fontSize={Math.max(
+              (inner_annulus_end - inner_annulus_start) * inner_scale,
+              11.2
+            )}
+            ticks={range(24).map((n) => ({
+              angle: (360 * n) / 24 + 540,
+              text:
+                n % show_local_times_divisible_by === 0 ? hourToString(n) : ".",
+              className: "sNone",
+              classNameText: "sFillInk"
+            }))}
+          />
+        )}
+      </Rotate>
 
       <text
         dx={cx}

--- a/src/circular-clock.tsx
+++ b/src/circular-clock.tsx
@@ -205,7 +205,7 @@ export default function CircularClock({
 
   return (
     <svg width={width} height={height}>
-      <Rotate cx={cx} cy={cy} angle={rotate}>
+      <Rotate cx={cx} cy={cy} angle={(rotate / 24) * 360}>
         {/* everything in here is calculated based on utc */}
         {/* and must be rotated according to the offset to utc */}
         {radius >= give_up_radius && (

--- a/src/clock.tsx
+++ b/src/clock.tsx
@@ -18,7 +18,7 @@ export interface ClockProps {
   loc: Location | null;
   highlighted_hours: Set<number>; // indexes (0 = candle) of hours to highlight
   hourTable: Record<number, HourOf>;
-  rotate: number; // Shift the clock interface by this many degrees (360 degrees equal 24 hours)
+  rotate: number; // Shift the clock interface by this many hours
 }
 
 // Everything you need to render a clock at a certain point in time.

--- a/src/clock.tsx
+++ b/src/clock.tsx
@@ -18,6 +18,7 @@ export interface ClockProps {
   loc: Location | null;
   highlighted_hours: Set<number>; // indexes (0 = candle) of hours to highlight
   hourTable: Record<number, HourOf>;
+  rotate: number; // Shift the clock interface by this many degrees (360 degrees equal 24 hours)
 }
 
 // Everything you need to render a clock at a certain point in time.
@@ -30,6 +31,7 @@ export interface ClockUiProps {
   sun_hours: SunHours | null;
   highlighted_hours: Set<number>; // indexes (0 = candle) of hours to highlight
   hourTable: Record<number, HourOf>;
+  rotate: number;
 }
 
 export interface SunHours {
@@ -82,6 +84,7 @@ export function Clock(props: ClockProps) {
       sun_hours={sun_hours}
       highlighted_hours={props.highlighted_hours}
       hourTable={props.hourTable}
+      rotate={props.rotate}
     />
   );
 }


### PR DESCRIPTION
You can rotate the full display by adding a search parameter of the form `rotate=<degrees_as_float>` to the url. By default, noon is at the top of the screen, but setting the rotation to `180` moves midnight to the top: [`https://seasonalclock.org/?rotate=180`](https://seasonalclock.org/?rotate=180)

Most of the diff is changing indentation, this is actually pretty small change.